### PR TITLE
Add Express Rate Limiter to API Routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "ioredis": "^5.4.2",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
@@ -2678,6 +2679,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "ioredis": "^5.4.2",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import express, { NextFunction, Request, Response } from "express";
 import { userRouter } from "./routes/user";
 import { bookRouter } from "./routes/books";
+import rateLimit from "express-rate-limit";
 
 const app = express();
 const port = 3000;
@@ -8,8 +9,27 @@ const port = 3000;
 // Middleware to parse JSON
 app.use(express.json());
 
+// express-rate-limit => 5min, 100 api request allowed
+const globalLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000,
+  limit: 100,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+});
+
+// applies to all api(s)
+app.use(globalLimiter);
+
+const userLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  limit: 100,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+});
+
 // Routes
-app.use("/api/v1/users", userRouter);
+// Applies to users api only
+app.use("/api/v1/users", userLimiter, userRouter);
 app.use("/api/v1/books", bookRouter);
 
 // Server route


### PR DESCRIPTION
### Description
This pull request introduces an Express rate limiter to enforce limits on API requests. The limiter restricts each client to a maximum of 100 requests within a 5-minute window. This will help prevent abuse and protect the server from being overwhelmed by excessive requests.

### Changes
- Implemented express-rate-limit middleware globally for all routes.
- Configured the rate limiter to allow up to 100 requests per 5 minutes per client.
- Disabled legacy rate-limit headers and set the standard headers to draft-8 for improved compatibility.

### This enhancement ensures that our API remains performant and resilient against unnecessary load.

### Additional Information:
The rate limiter provides helpful headers such as RateLimit-Limit, RateLimit-Remaining, and RateLimit-Reset to clients, providing real-time information about their request status.

### Related Issues:
N/A (No related issues)